### PR TITLE
Add pretend requirement for testing.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,4 @@ pytest
 pytest-cov
 twisted
 pyopenssl
+pretend


### PR DESCRIPTION
Right now `pip install -r dev-requirements.txt` is insufficient to get `py.test test_pem.py` to work.
